### PR TITLE
Add tests for routing module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - "master"
-      - "CI"
   pull_request:
     branches:
       - "master"
-      - "CI"
 
 jobs:
   test:

--- a/latex_access/tests/test_path.py
+++ b/latex_access/tests/test_path.py
@@ -5,8 +5,8 @@ from latex_access.path import get_path
 class TestPath(unittest.TestCase):
     def test_is_directory(self):
         """Test that  path is an existing directory."""
-        assert os.path.isdir(get_path()) == True
+        self.assertTrue (os.path.isdir(get_path()))
 
     def test_is_absolute_path(self):
         "Test that  path is an absolute pathname."""
-        assert os.path.isabs(get_path()) == True
+        self.assertTrue(os.path.isabs(get_path()))

--- a/latex_access/tests/test_routing.py
+++ b/latex_access/tests/test_routing.py
@@ -1,0 +1,19 @@
+import unittest
+from latex_access.routing import convert, invert
+
+class TestRouting(unittest.TestCase):
+    def test_empty_list(self):
+        """Testst that empty list is returned for empty input."""
+        self.assertEqual(convert([]), [])
+
+    def test_two_tuples(self):
+        """Tests that right elements are returned for two tuples with three elements each."""
+        self.assertEqual(convert([(1, 2, 3), (4, 5, 6)]), [2, 2, 2, 5])
+
+    def test_three_tuples(self):
+        """Tests that right elements are returned for three tuples with two elements each."""
+        self.assertEqual(convert([(1, 2), (3, 4), (5, 6)]), [2, 2, 4, 4, 6])
+
+    def test_inversion(self):
+        """Tests that tuples are inverted properly."""
+        self.assertEqual(invert([(0, 1)]), [(1, 0)])


### PR DESCRIPTION
This pull request adds tests for routing module. It consists of two functions - convert and invert. Convert creates a flat list from list of tuples. Tests are made for empty list as well as few different tuples. Invert swaps elements in a tuple. Test checks if inversion is correct.
This PR also fixes some issues resulted from #4 - it removes unused branch from CI pipeline and changes the type of assertions in path module in order to be consistent across all thests.