### PR TITLE
Make library Python 3 compatible

### DIFF
--- a/latex_access/back_compat.py
+++ b/latex_access/back_compat.py
@@ -1,0 +1,10 @@
+"""Holds various constants used to preserve backwards compatibility with Python 2."""
+
+try:
+    import __builtin__
+except ImportError:
+    STR_AND_UNICODE = str
+    STR_TYPE = str  # No separate type for non-unicode strings in Python 3.
+else:  # Python 2
+    STR_AND_UNICODE = __builtin__.basestring
+    STR_TYPE = __builtin__.str

--- a/latex_access/hungarian_speech.py
+++ b/latex_access/hungarian_speech.py
@@ -14,6 +14,8 @@
 #
 '''Module to provide speech output for latex_access.'''
 
+from __future__ import absolute_import
+
 from latex_access import latex_access
 from latex_access.latex_access import get_arg
 import re

--- a/latex_access/hungarian_speech.py
+++ b/latex_access/hungarian_speech.py
@@ -40,9 +40,8 @@ class speech(latex_access.translator):
 		self.load_files()
 		
 		new_table={"\\cap":self.cap, "\\bigcap":self.cap, "\\binom":self.binom,"\\vec":self.vect,"\\underline":self.underline,"$":self.dollar,"^":self.super,"_":("<sub>","</sub>"),"\\pmod":("mod <sub>","</sub>"),"\\widetilde":self.tilde,"\\tilde":self.tilde,"\\sqrt":self.sqrt,"\\frac":self.frac,"\\dfrac":self.frac,"\\ds":self.dsfrac,"\\int":self.integral,"\\dbint":self.dbintegral,"\\ddint":self.ddintegral,"\\oint":self.ointegral,"\\cup":self.union,"\\bigcup":self.union,"\\sum":self.sum,"\\prod":self.prod,"\\bf":("<bold>","</bold>"),"\\mathbf":("<bold>","</bold>"),"\\mathbb":("<bold>","</bold>"),"\\mathcal":("<mathcal>","</mathcal>"), "\\em":("<em>","</em>"), "\\it":("<em>","</em>"), "\\log":self.log,"\\ang":self.ang,"\\tag":self.tag,"\\hat":self.hat,"\\widehat":self.hat,"\\bar":("",u" felülvonás "),"\\overline":self.overline,"\\dot":("","pont"),"\\ddot":("","duplapont")}
-		for (k,v) in new_table.iteritems():
-			self.table[k]=v
-			self.space=" "
+		self.table.update(new_table)
+		self.space=" "
 
 
 	def correct(self, inputstr):

--- a/latex_access/hungarian_speech.py
+++ b/latex_access/hungarian_speech.py
@@ -14,8 +14,8 @@
 #
 '''Module to provide speech output for latex_access.'''
 
-import latex_access
-from latex_access import get_arg
+from latex_access import latex_access
+from latex_access.latex_access import get_arg
 import re
 
 primes=re.compile(r"^\s*(\\p+rime\s*)+$")

--- a/latex_access/latex_access.py
+++ b/latex_access/latex_access.py
@@ -16,13 +16,14 @@
 
 from __future__ import absolute_import
 
+import inspect
 import re
-import types
 import os.path
 
 from latex_access.path import get_path
 import codecs
 from latex_access import routing
+from latex_access import back_compat
 
 # Regular expression to match LaTeX commands
 latex_command=re.compile(r"\\(([a-zA-Z]+)|[,!;\{\}\[\];:])")
@@ -133,16 +134,16 @@ class translator:
             if curr in self.table:
                 i+=len(curr)
                 result=self.table[curr]
-                if type(result) in (types.StringType,types.UnicodeType):
+                if isinstance(result, back_compat.STR_AND_UNICODE):
                     output+=self.space
                     output += result
                     output+=self.space
-                elif type(result)==types.TupleType or type(result)==types.ListType:
+                elif isinstance(result, (tuple, list)):
                     if rting==(): translation=self.general_command(input,i,result)
                     else: translation=self.general_command(input,i,result,(rting[0],rting[1]+len(output)))
                     output+=translation[0]
                     i=translation[1]                    
-                elif type(result) == types.MethodType:
+                elif inspect.ismethod(result):
                     if rting!=():
                         try: translation=result(input,i,(rting[0],rting[1]+len(output)))
                         except: translation=result(input,i)
@@ -208,7 +209,7 @@ class translator:
         An integer refers to the corresponding argument which is translated and inserted into the string.
 
         Returns usual tuple.'''
-        if type(delimitors[0])==types.StringType:
+        if isinstance(delimitors[0], back_compat.STR_TYPE):
             translation=self.space
             translation+=delimitors[0]
             translation+=self.space
@@ -228,7 +229,7 @@ class translator:
                 start=arg[1]
             translation=self.space
             for x in delimitors[1:]:
-                if type(x) in (types.StringType,types.UnicodeType):
+                if isinstance(x, back_compat.STR_AND_UNICODE):
                     translation+=x
                     translation+=self.space
                 else:

--- a/latex_access/latex_access.py
+++ b/latex_access/latex_access.py
@@ -14,6 +14,8 @@
 
 '''This module provides translations of lines of LaTeX into either braille or spoken output.'''
 
+from __future__ import absolute_import
+
 import re
 import types
 import os.path

--- a/latex_access/latex_access.py
+++ b/latex_access/latex_access.py
@@ -17,9 +17,10 @@
 import re
 import types
 import os.path
-from .path import get_path
+
+from latex_access.path import get_path
 import codecs
-from . import routing
+from latex_access import routing
 
 # Regular expression to match LaTeX commands
 latex_command=re.compile(r"\\(([a-zA-Z]+)|[,!;\{\}\[\];:])")

--- a/latex_access/latex_access_com.py
+++ b/latex_access/latex_access_com.py
@@ -16,9 +16,9 @@
 #screenreaders and the latex access scripts
 
 
-import preprocessor
-import speech
-import settings
+from latex_access import preprocessor
+from latex_access import speech
+from latex_access import settings
 import os
 
 class latex_access_com:

--- a/latex_access/latex_access_emacs.py
+++ b/latex_access/latex_access_emacs.py
@@ -22,6 +22,8 @@
 """Silly hack to access translate functions as pymacs was difficult to
 interact with classes."""
 
+from __future__ import absolute_import
+
 import sys
 import os.path
 from latex_access import settings

--- a/latex_access/latex_access_emacs.py
+++ b/latex_access/latex_access_emacs.py
@@ -43,7 +43,7 @@ matrix.row=1
 matrix.column=1
 
 if __name__ == "__main__":
-    print "This is just a module."
+    print("This is just a module.")
     exit (-1)
 
 def activateSettings ():

--- a/latex_access/latex_access_emacs.py
+++ b/latex_access/latex_access_emacs.py
@@ -24,13 +24,13 @@ interact with classes."""
 
 import sys
 import os.path
-import settings
-import speech
-import nemeth
-import ueb
-import preprocessor
-import matrix_processor
-import table as t
+from latex_access import settings
+from latex_access import speech
+from latex_access import nemeth
+from latex_access import ueb
+from latex_access import preprocessor
+from latex_access import matrix_processor
+from latex_access import table as t
 
 s=speech.speech()
 n=''

--- a/latex_access/nemeth.py
+++ b/latex_access/nemeth.py
@@ -16,8 +16,8 @@
 module.'''
 
 
-from . import latex_access
-from .latex_access import get_arg
+from latex_access import latex_access
+from latex_access.latex_access import get_arg
 
 class nemeth(latex_access.translator):
     '''Class for nemeth translations.'''

--- a/latex_access/nemeth.py
+++ b/latex_access/nemeth.py
@@ -15,6 +15,7 @@
 '''Module to provide Nemeth translations for the latex_access
 module.'''
 
+from __future__ import absolute_import
 
 from latex_access import latex_access
 from latex_access.latex_access import get_arg

--- a/latex_access/preprocessor.py
+++ b/latex_access/preprocessor.py
@@ -62,8 +62,7 @@ class preprocessor(latex_access.translator):
         f = open(filename, "rb")
         newtable=pickle.load(f)
         f.close()
-        for (k,v) in newtable.iteritems():
-            self.table[k]=v
+        self.table.update(newtable)
 
 class newcommands(latex_access.translator):
     '''Provides a translator to extract all \newcommand commands from a string.'''

--- a/latex_access/preprocessor.py
+++ b/latex_access/preprocessor.py
@@ -17,7 +17,7 @@
 For example it can be used to handle commands defined by \newcommand.'''
 
 import cPickle as pickle
-import latex_access
+from latex_access import latex_access
 
 
 class preprocessor(latex_access.translator):

--- a/latex_access/preprocessor.py
+++ b/latex_access/preprocessor.py
@@ -18,7 +18,11 @@ For example it can be used to handle commands defined by \newcommand.'''
 
 from __future__ import absolute_import
 
-import cPickle as pickle
+try:
+    import cPickle as pickle  # Python 2
+except ImportError:
+    import pickle  # Python 3
+
 from latex_access import latex_access
 
 

--- a/latex_access/preprocessor.py
+++ b/latex_access/preprocessor.py
@@ -16,6 +16,8 @@
 
 For example it can be used to handle commands defined by \newcommand.'''
 
+from __future__ import absolute_import
+
 import cPickle as pickle
 from latex_access import latex_access
 

--- a/latex_access/preprocessor.py
+++ b/latex_access/preprocessor.py
@@ -53,13 +53,13 @@ class preprocessor(latex_access.translator):
 
     def write(self, filename):
         '''Saves the preprocessor entries to a file.'''
-        f=open(filename,"w")
-        pickle.dump(self.table,f)
+        f = open(filename, "wb")
+        pickle.dump(self.table, f, protocol=0)
         f.close()
 
     def read(self, filename):
         '''Reads preprocessor entries from a file and appends them to the dictionary.'''
-        f=open(filename)
+        f = open(filename, "rb")
         newtable=pickle.load(f)
         f.close()
         for (k,v) in newtable.iteritems():

--- a/latex_access/settings.py
+++ b/latex_access/settings.py
@@ -13,8 +13,8 @@
 #    You should have received a copy of the GNU General Public License along with this program; if not, visit <http://www.gnu.org/licenses>
 
 import os
-from . import ueb
-from . import nemeth
+from latex_access import ueb
+from latex_access import nemeth
 
 globals
 # Global settings for latex-access, these are the default values

--- a/latex_access/settings.py
+++ b/latex_access/settings.py
@@ -12,6 +12,8 @@
 #
 #    You should have received a copy of the GNU General Public License along with this program; if not, visit <http://www.gnu.org/licenses>
 
+from __future__ import absolute_import
+
 import os
 from latex_access import ueb
 from latex_access import nemeth

--- a/latex_access/speech.py
+++ b/latex_access/speech.py
@@ -15,6 +15,7 @@
 #
 '''Module to provide speech output for latex_access.'''
 
+from __future__ import absolute_import
 
 from latex_access import latex_access
 from latex_access.latex_access import get_arg

--- a/latex_access/speech.py
+++ b/latex_access/speech.py
@@ -16,8 +16,8 @@
 '''Module to provide speech output for latex_access.'''
 
 
-from . import latex_access
-from .latex_access import get_arg
+from latex_access import latex_access
+from latex_access.latex_access import get_arg
 
 #Define a list of words to use as denominators of simple fractions
 denominators=[" over zero"," over1 "," half"," third"," quarter"," fifth"," sixth"," seventh"," eight"," ninth"]

--- a/latex_access/speech_modified.py
+++ b/latex_access/speech_modified.py
@@ -41,8 +41,7 @@ class speech(latex_access.translator):
                 "\\tag":self.tag,"\\hat":("","hat"),"\\widehat":("","hat"),"\\bar":("","bar"),
                 "\\overline":("","bar"),"\\dot":("","dot"),"\\ddot":("","double dot"),"\\sum":self.sum,"\\prod":self.prod,"\\cup":self.union,"\\bigcup":self.union}
         
-        for (k,v) in new_table.iteritems():
-            self.table[k]=v
+        self.table.update(new_table)
         self.space=" "
         
     sqrt_with_two_args =re.compile(r".*\\sqrt\[(.*)\]+.*")

--- a/latex_access/speech_modified.py
+++ b/latex_access/speech_modified.py
@@ -16,6 +16,7 @@
 #
 '''Module to provide speech output for latex_access.'''
 
+from __future__ import absolute_import
 
 from latex_access import latex_access
 from latex_access.latex_access import get_arg

--- a/latex_access/speech_modified.py
+++ b/latex_access/speech_modified.py
@@ -17,8 +17,8 @@
 '''Module to provide speech output for latex_access.'''
 
 
-import latex_access
-from latex_access import get_arg
+from latex_access import latex_access
+from latex_access.latex_access import get_arg
 import re
 
 #Define a list of words to use as denominators of simple fractions

--- a/latex_access/ssml.py
+++ b/latex_access/ssml.py
@@ -15,8 +15,8 @@
 '''Experimental Module to provide speech output in SSML for latex_access.'''
 
 
-import speech
-from latex_access import get_arg
+from latex_access import speech
+from latex_access.latex_access import get_arg
 
 sb='<break strength="strong">'
 

--- a/latex_access/ssml.py
+++ b/latex_access/ssml.py
@@ -14,6 +14,7 @@
 #
 '''Experimental Module to provide speech output in SSML for latex_access.'''
 
+from __future__ import absolute_import
 
 from latex_access import speech
 from latex_access.latex_access import get_arg

--- a/latex_access/table.py
+++ b/latex_access/table.py
@@ -43,7 +43,7 @@ from a LaTeX tabular environment, providing useful information to the
 document author when working with tables."""
 
 if __name__ == "__main__":
-  print "This can only be used as a module, and does nothing when called interactively."
+  print("This can only be used as a module, and does nothing when called interactively.")
   exit (-1)
   
 def BuildHeaderString (text):

--- a/latex_access/table.py
+++ b/latex_access/table.py
@@ -119,7 +119,7 @@ def GetTablePosition (table,currrow):
   alph=("A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z")
   position = "" # Null to begin 
   if column >= 26: # Need two letter column identification 
-    position=position+alph[(column/26)-1] 
+    position = position + alph[(column // 26) -1]
     position=position+" "+alph[column%26]
   else: # less than 26 cols (one letter identifier)
     position=position+alph[column]

--- a/latex_access/ueb.py
+++ b/latex_access/ueb.py
@@ -16,9 +16,9 @@
 module.'''
 
 
-from . import latex_access
-from .latex_access import get_arg
-from .latex_access import get_optional_arg
+from latex_access import latex_access
+from latex_access.latex_access import get_arg
+from latex_access.latex_access import get_optional_arg
 
 class ueb(latex_access.translator):
     '''Class for ueb translations.'''

--- a/latex_access/ueb.py
+++ b/latex_access/ueb.py
@@ -15,6 +15,7 @@
 '''Module to provide UEB translations for the latex_access
 module.'''
 
+from __future__ import absolute_import
 
 from latex_access import latex_access
 from latex_access.latex_access import get_arg

--- a/latex_access/ueb.py
+++ b/latex_access/ueb.py
@@ -44,9 +44,8 @@ class ueb(latex_access.translator):
 
         for letter in range (97,123): # Ascii, lower case
             new_table["%c" % (letter)] = self.lowerLetter
-    
-        for (k,v) in new_table.iteritems():
-            self.table[k]=v
+
+        self.table.update(new_table)
 
     def before (self):
         """Method ran before the translator at depth = 0.


### PR DESCRIPTION
Closes #18

This pull request makes the main translator package compatible with Python 3. It is still kept backwards compatible with Python 2. Frontend's to screen readers would be migrated at a later stage.