### PR TITLE
Modify tests which load data from the preprocessor file

### DIFF
--- a/latex_access/tests/test_latex_access_emacs.py
+++ b/latex_access/tests/test_latex_access_emacs.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 import unittest
-import pickle
 import tempfile
 try:
     from latex_access.latex_access_emacs import *
@@ -44,9 +43,10 @@ class TestsLatexAccessEmacs(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as file:
             p.table['foo'] = 'bar'
             preprocessor_write(file.name)
-        with open(file.name, "r") as f:
-            temp_table = pickle.load(f)
-        self.assertEqual(temp_table['foo'], 'bar')
+        del p.table["foo"]
+        self.assertNotIn("foo", p.table)
+        preprocessor_read(file.name)
+        self.assertEqual(p.table['foo'], 'bar')
 
     def test_read(self):
         """Tests that preprocessor entries can be read from a file."""

--- a/latex_access/tests/test_preprocessor.py
+++ b/latex_access/tests/test_preprocessor.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 import tempfile
-import pickle
 
 try:
     from latex_access import preprocessor
@@ -38,9 +37,9 @@ class TestPreprocessor(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as file:
             self.preprocessor.table['foo'] = 'bar'
             self.preprocessor.write(file.name)
-        with open(file.name, "r") as f:
-            temp_table = pickle.load(f)
-        self.assertEqual(temp_table['foo'], 'bar')
+        clean_preproc = preprocessor.preprocessor()
+        clean_preproc.read(file.name)
+        self.assertEqual(clean_preproc.table["foo"], "bar")
 
     def test_read(self):
         """Tests that preprocessor entries can be read from a file."""


### PR DESCRIPTION
Prerequisite for #24 
Tests for preprocessor used to verify that its content can be written successfully by reading the created file, and checking its structure. What is interesting for the preprocessor consumers however, is a confirmation that saved entries can be loaded into a fresh instance.
This PR modifies tests accordingly. This also means that we don't have to know in what format these entries are written - having a file is sufficient.
This change was necessary when making library Python 3 compatible - I've decided to submit it separately, to avoid modifying tests in the migration Pr.