### PR TITLE
Add additional unit tests for speech translators to improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.pyo
 .pytest_cache
+.coverage


### PR DESCRIPTION
This pull request adds additional uni tests for all speech translators to improve their coverage (for English ones this only improves branch coverage). Since I was unable to quickly figure out why tests for angles and roots in legacy speech weren't covering some code I've taken the liberty to rewrite them from scratch. For English translators the coverage including branches is at 100%. For the Hungarian one this cannot be achieved, since code is written incorrectly in some places. Given I don't know the language I'm reluctant to touch the translator itself at this stage. While at it I've also fixed some warnings about backslashes in strings and legacy assertion methods in tests. My main motivation for looking into this were the tests for angles since the same branches aren't covered in the Polish speech translator - I'll add the tests from this PR to #27 tomorrow.